### PR TITLE
Button events

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
 	"scripts": {
+    "bootstrap": "node ./node_modules/lerna/bin/lerna bootstrap",
 		"precommit": "lerna run lint && lerna run build && lerna run test"
 	},
 	"devDependencies": {

--- a/packages/gtk-node/src/Button.cpp
+++ b/packages/gtk-node/src/Button.cpp
@@ -11,7 +11,11 @@ void Button::clicked() {
   });
 }
 
+IMPLEMENT_EVENT(Button, onRelease, signal_released)
 IMPLEMENT_EVENT(Button, onClick, signal_clicked)
+IMPLEMENT_EVENT(Button, onEnter, signal_enter)
+IMPLEMENT_EVENT(Button, onLeave, signal_leave)
+IMPLEMENT_EVENT(Button, onActivate, signal_activate)
 IMPLEMENT_GETTER(Button, string, getLabel, get_label)
 IMPLEMENT_SETTER(Button, string, setLabel, set_label)
 
@@ -19,7 +23,11 @@ NBIND_CLASS(Button) {
   NBIND_INHERIT(Widget);
   NBIND_CONSTRUCT<>();
   NBIND_CONSTRUCT<std::string>();
+  NBIND_METHOD(onRelease);
   NBIND_METHOD(onClick);
+  NBIND_METHOD(onEnter);
+  NBIND_METHOD(onLeave);
+  NBIND_METHOD(onActivate);
   NBIND_METHOD(setLabel);
   NBIND_METHOD(getLabel);
   NBIND_METHOD(clicked);

--- a/packages/gtk-node/src/Button.hpp
+++ b/packages/gtk-node/src/Button.hpp
@@ -12,7 +12,11 @@ using namespace std;
 
 class Button : public Widget {
 BASIC_WIDGET(Gtk::Button, Button)
+DEFINE_EVENT(onRelease)
 DEFINE_EVENT(onClick)
+DEFINE_EVENT(onEnter)
+DEFINE_EVENT(onLeave)
+DEFINE_EVENT(onActivate)
 DEFINE_GETTER(string, getLabel)
 DEFINE_SETTER(string, setLabel)
 


### PR DESCRIPTION
I also added `npm run bootstrap`. It seems much cleaner than `node ./node_modules/lerna/bin/learna bootstrap`.

Since gtk doesn't have functions for calling buttons signals other than signal_clicked, there's not really a clear way to test the other button events.